### PR TITLE
Fix compatibility with Connector/C >= 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ sudo: false
 warnings_are_errors: true
 
 service: mysql
-addons:
-  apt:
-    packages:
-    - libmysqlclient-dev
 env:
   global:
   - NOT_CRAN: true
@@ -22,12 +18,28 @@ matrix:
     r: release
     env:
     - R_CODECOV: true
+    addons:
+      apt:
+        packages:
+        - libmariadbclient-dev
   - os: linux
     r: devel
+    addons:
+      apt:
+        packages:
+        - libmysqlclient-dev
   - os: linux
     r: oldrel
+    addons:
+      apt:
+        packages:
+        - libmysqlclient-dev
   - os: linux
     r: 3.2
+    addons:
+      apt:
+        packages:
+        - libmysqlclient-dev
   - os: osx
     osx_image: xcode8.3
     before_install:

--- a/src/MariaResultPrep.cpp
+++ b/src/MariaResultPrep.cpp
@@ -152,7 +152,6 @@ bool MariaResultPrep::fetch_row() {
 
   switch (result) {
   // We expect truncation whenever there's a string or blob
-  case MYSQL_DATA_TRUNCATED:
   case 0:
     return true;
   case 1:


### PR DESCRIPTION
Avoid calling `mysql_stmt_bind_result()`, instead call `mysql_stmt_fetch_column()` twice if necessary.

Fixes #69.