### PR TITLE
Check that input to `dbWriteTable` is a data frame

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -81,6 +81,10 @@ setMethod("dbWriteTable", c("MariaDBConnection", "character", "data.frame"),
            overwrite = FALSE, append = FALSE, ...,
            temporary = FALSE) {
 
+    if (!is.data.frame(value))  {
+      stopc("`value` must be data frame")
+    }
+    
     row.names <- compatRowNames(row.names)
 
     if ((!is.logical(row.names) && !is.character(row.names)) || length(row.names) != 1L)  {


### PR DESCRIPTION
It's fairly easy to accidentally pass a vector to `dbWriteTable`, and the error message is unhelpful. I've added a simple check, with a more helpful error message.

Currently, the error displayed is:
> unable to find inherited method...

I triggered the error using `data.table` like so
```R
dbWriteTable(con, "name", dt[ , a ])
```

What I should have done was
```R
dbWriteTable(con, "name", dt[ , .(a) ])
```

Others have had similar problems, trying to pass a single column using the `$` operator on data frames, [eg here on SO](https://stackoverflow.com/questions/40480273/how-to-fix-dbwritetable-error-unable-to-find-an-inherited-method-for-function)