### PR TITLE
CRAN release v1.0.10

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RMariaDB
 Title: Database Interface and 'MariaDB' Driver
-Version: 1.0.9.9001
+Version: 1.0.10
 Authors@R: 
     c(person(given = "Kirill",
              family = "M\u00fcller",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# RMariaDB 1.0.10 (2020-08-26)
+
+- Internal changes only.
+
+
 # RMariaDB 1.0.9.9001 (2020-08-26)
 
 - `dbConnect()` gains a `timeout` argument, defaults to 10. Use `Inf` or a negative value for no timeout (#169).

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,20 +1,20 @@
-RMariaDB 1.0.9
+RMariaDB 1.0.10
 
 ## Cran Repository Policy
 
-- [x] Reviewed CRP last edited 2020-05-21.
+- [x] Reviewed CRP last edited 2020-07-11.
 
 ## R CMD check results
 
-- [x] Checked locally, R 4.0.1
-- [x] Checked on CI system, R 4.0.2
-- [x] Checked on win-builder, R devel
+- [x] Checked locally, R 4.0.2
+- [ ] Checked on CI system, R 4.0.2
+- [ ] Checked on win-builder, R devel
 
-OK
+- [ ] Check the boxes above after successful execution and remove this line. Then run `fledge::release()`.
 
-## CRAN failures
+## Current CRAN check results
 
-- [x] Checked on 2020-07-03, notes found
-- [x] NOTE: r-devel-windows-ix86+x86_64, r-release-osx-x86_64, r-release-windows-ix86+x86_64, r-oldrel-osx-x86_64, r-oldrel-windows-ix86+x86_64: compiled library is large on Windows and OS X
+- [x] Checked on 2020-08-26, errors found: https://cran.r-project.org/web/checks/check_results_RMariaDB.html
+- [ ] NOTE: r-devel-windows-ix86+x86_64, r-release-macos-x86_64, r-release-windows-ix86+x86_64, r-oldrel-macos-x86_64, r-oldrel-windows-ix86+x86_64
 
 Check results at: https://cran.r-project.org/web/checks/check_results_RMariaDB.html


### PR DESCRIPTION
RMariaDB 1.0.10

## Cran Repository Policy

- [x] Reviewed CRP last edited 2020-07-11.

## R CMD check results

- [x] Checked locally, R 4.0.2
- [ ] Checked on CI system, R 4.0.2
- [ ] Checked on win-builder, R devel

- [ ] Check the boxes above after successful execution and remove this line. Then run `fledge::release()`.

## Current CRAN check results

- [x] Checked on 2020-08-26, errors found: https://cran.r-project.org/web/checks/check_results_RMariaDB.html
- [ ] NOTE: r-devel-windows-ix86+x86_64, r-release-macos-x86_64, r-release-windows-ix86+x86_64, r-oldrel-macos-x86_64, r-oldrel-windows-ix86+x86_64

Check results at: https://cran.r-project.org/web/checks/check_results_RMariaDB.html
