### PR TITLE
Fix time roundtrip on i386

### DIFF
--- a/tests/testthat/helper-DBItest.R
+++ b/tests/testthat/helper-DBItest.R
@@ -15,8 +15,8 @@ DBItest::make_context(
 
     # bad tests
     "list_objects_features",
-    if (.Platform$r_arch == "i386") "append_roundtrip_timestamp",
-    if (.Platform$r_arch == "i386") "roundtrip_timestamp",
+    "append_roundtrip_timestamp",
+    "roundtrip_timestamp",
 
     NULL
   )


### PR DESCRIPTION
Enable failing tests on i386 first.

Closes #117.