### PR TITLE
Fix resolving of '~' in 'default.file'

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -102,6 +102,11 @@ setMethod("dbConnect", "MariaDBDriver",
       timeout <- as.integer(timeout)
     }
 
+    # Make sure that `~` is resolved correctly:
+    if (!is.null(default.file)) {
+      default.file <- normalizePath(default.file)
+    }
+
     ptr <- connection_create(
       host, username, password, dbname, as.integer(port), unix.socket,
       as.integer(client.flag), groups, default.file,


### PR DESCRIPTION
This fixes #197 for me.

I wonder if this should also be done for `ssl.capath`, but I have no means to test this.