### PR TITLE
Fix resolving of '~' in 'default.file'

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -33,14 +33,16 @@ NULL
 #' @param default.file string of the filename with MariaDB client options,
 #'   only relevant if `groups` is given. The default value depends on the
 #'   operating system (see references), on Linux and OS X the files
-#'   `~/.my.cnf` and `~/.mylogin.cnf` are used.
+#'   `~/.my.cnf` and `~/.mylogin.cnf` are used. Expanded with [normalizePath].
 #' @param ssl.key (optional) string of the filename of the SSL key file to use.
+#'   Expanded with [normalizePath].
 #' @param ssl.cert (optional) string of the filename of the SSL certificate to
-#'   use.
+#'   use. Expanded with [normalizePath].
 #' @param ssl.ca (optional) string of the filename of an SSL certificate
-#'   authority file to use.
+#'   authority file to use. Expanded with [normalizePath].
 #' @param ssl.capath (optional) string of the path to a directory containing
-#'   the trusted SSL CA certificates in PEM format.
+#'   the trusted SSL CA certificates in PEM format. Expanded with
+#'   [normalizePath].
 #' @param ssl.cipher (optional) string list of permitted ciphers to use for SSL
 #'   encryption.
 #' @param ... Unused, needed for compatibility with generic.
@@ -105,6 +107,18 @@ setMethod("dbConnect", "MariaDBDriver",
     # Make sure that `~` is resolved correctly:
     if (!is.null(default.file)) {
       default.file <- normalizePath(default.file)
+    }
+    if (!is.null(ssl.key)) {
+      ssl.key <- normalizePath(ssl.key)
+    }
+    if (!is.null(ssl.cert)) {
+      ssl.cert <- normalizePath(ssl.cert)
+    }
+    if (!is.null(ssl.ca)) {
+      ssl.ca <- normalizePath(ssl.ca)
+    }
+    if (!is.null(ssl.capath)) {
+      ssl.capath <- normalizePath(ssl.capath)
     }
 
     ptr <- connection_create(

--- a/R/connect.R
+++ b/R/connect.R
@@ -102,6 +102,11 @@ setMethod("dbConnect", "MariaDBDriver",
       timeout <- as.integer(timeout)
     }
 
+    # Make sure that `~` is resolved correctly:
+    if (!is.null(default.file)) {
+      default.file <- normalizePath(default.file)
+    }
+
     ptr <- connection_create(
       host, username, password, dbname, as.integer(port), unix.socket,
       as.integer(client.flag), groups, default.file,

--- a/man/dbConnect-MariaDBDriver-method.Rd
+++ b/man/dbConnect-MariaDBDriver-method.Rd
@@ -58,18 +58,20 @@ for setting authentication parameters (see \code{\link[=MariaDB]{MariaDB()}}).}
 \item{default.file}{string of the filename with MariaDB client options,
 only relevant if \code{groups} is given. The default value depends on the
 operating system (see references), on Linux and OS X the files
-\verb{~/.my.cnf} and \verb{~/.mylogin.cnf} are used.}
+\verb{~/.my.cnf} and \verb{~/.mylogin.cnf} are used. Expanded with \link{normalizePath}.}
 
-\item{ssl.key}{(optional) string of the filename of the SSL key file to use.}
+\item{ssl.key}{(optional) string of the filename of the SSL key file to use.
+Expanded with \link{normalizePath}.}
 
 \item{ssl.cert}{(optional) string of the filename of the SSL certificate to
-use.}
+use. Expanded with \link{normalizePath}.}
 
 \item{ssl.ca}{(optional) string of the filename of an SSL certificate
-authority file to use.}
+authority file to use. Expanded with \link{normalizePath}.}
 
 \item{ssl.capath}{(optional) string of the path to a directory containing
-the trusted SSL CA certificates in PEM format.}
+the trusted SSL CA certificates in PEM format. Expanded with
+\link{normalizePath}.}
 
 \item{ssl.cipher}{(optional) string list of permitted ciphers to use for SSL
 encryption.}


### PR DESCRIPTION
This fixes #197 for me.

I wonder if this should also be done for ssl.capath, but I have no means to test that.