### PR TITLE
Make ~/.my.cnf robust to #s

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ If you want to run the examples, you'll need to set the proper options in the `[
 
 ```
 [rs-dbi]
-database=test
-user=root
-password=
+database="test"
+user="root"
+password=""
 ```
 
 ## Acknowledgements


### PR DESCRIPTION
If you have a # in your password, this will currently fail cryptically, telling you your password is wrong.