### PR TITLE
Port configure tweak from RMySQL

### DIFF
--- a/configure
+++ b/configure
@@ -49,7 +49,7 @@ elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
     PKG_LIBS="-L/usr/local/opt/openssl/lib $PKG_LIBS"
   fi
 elif [ `uname` = "Darwin" ]; then
-  brew --version 2>/dev/null
+  test ! "$CI" && brew --version 2>/dev/null
   if [ $? -eq 0 ]; then
     BREWDIR=`brew --prefix`
   else


### PR DESCRIPTION
Small tweak that enables autobrew in CI, which smoothens the github-action for other packages that depend on this package.