### PR TITLE
test: Test for quoting columns with `dbQuoteIdentifier()`

### DIFF
--- a/R/dbQuoteIdentifier_MariaDBConnection_Id.R
+++ b/R/dbQuoteIdentifier_MariaDBConnection_Id.R
@@ -1,9 +1,6 @@
 #' @name mariadb-quoting
 #' @usage NULL
 dbQuoteIdentifier_MariaDBConnection_Id <- function(conn, x, ...) {
-  if (length(x@name) >= 3 && any(x@name[[length(x@name) - 2]] != "def")) {
-    stop('If a "catalog" component is supplied in `Id()`, it must be equal to "def" everywhere.', call. = FALSE)
-  }
   SQL(paste0(dbQuoteIdentifier(conn, x@name), collapse = "."))
 }
 

--- a/tests/testthat/test-dbQuoteIdentifier.R
+++ b/tests/testthat/test-dbQuoteIdentifier.R
@@ -1,0 +1,102 @@
+test_that("quoting string", {
+  con <- mariadbDefault()
+  on.exit(dbDisconnect(con))
+
+  quoted <- dbQuoteIdentifier(con, "Robert'); DROP TABLE Students;--")
+  expect_s4_class(quoted, 'SQL')
+  expect_equal(as.character(quoted),
+               "`Robert'); DROP TABLE Students;--`")
+})
+
+test_that("quoting SQL", {
+  con <- mariadbDefault()
+  on.exit(dbDisconnect(con))
+
+  quoted <- dbQuoteIdentifier(con, SQL("Robert'); DROP TABLE Students;--"))
+  expect_s4_class(quoted, 'SQL')
+  expect_equal(as.character(quoted),
+               "Robert'); DROP TABLE Students;--")
+})
+
+test_that("quoting Id", {
+  con <- mariadbDefault()
+  on.exit(dbDisconnect(con))
+
+  quoted <- dbQuoteIdentifier(con, Id(schema = 'Robert', table = 'Students;--'))
+  expect_s4_class(quoted, 'SQL')
+  expect_equal(as.character(quoted),
+               "`Robert`.`Students;--`")
+})
+
+test_that("quoting Id with column, #254", {
+  con <- mariadbDefault()
+  on.exit(dbDisconnect(con))
+
+  quoted <- dbQuoteIdentifier(con, Id(schema = 'Robert', table = 'Students;--', column = "dormitory"))
+  expect_s4_class(quoted, 'SQL')
+  expect_equal(as.character(quoted),
+               "`Robert`.`Students;--`.`dormitory`")
+})
+
+test_that("quoting Id with column, unordered", {
+  con <- mariadbDefault()
+  on.exit(dbDisconnect(con))
+
+  quoted <- dbQuoteIdentifier(con, Id(column = "dormitory", table = 'Students;--'))
+  expect_s4_class(quoted, 'SQL')
+  expect_equal(as.character(quoted),
+               "`Students;--`.`dormitory`")
+})
+
+test_that("quoting errors", {
+  con <- mariadbDefault()
+  on.exit(dbDisconnect(con))
+
+  expect_error(dbQuoteIdentifier(con, Id(tabel = 'Robert')),
+               "components")
+  expect_error(dbQuoteIdentifier(con, Id(table = 'Robert', table = 'Students;--')),
+               "Duplicated")
+})
+
+test_that("unquoting identifier - SQL with quotes", {
+  con <- mariadbDefault()
+  on.exit(dbDisconnect(con))
+
+  expect_equal(dbUnquoteIdentifier(con, SQL('`Students;--`')),
+               list(Id(table = 'Students;--')))
+
+  expect_equal(dbUnquoteIdentifier(con, SQL('`Robert`.`Students;--`')),
+               list(Id(schema = 'Robert', table = 'Students;--')))
+
+  expect_equal(dbUnquoteIdentifier(con, SQL('`Rob``ert`.`Students;--`')),
+               list(Id(schema = 'Rob`ert', table = 'Students;--')))
+
+  expect_equal(dbUnquoteIdentifier(con, SQL('`Rob.ert`.`Students;--`')),
+               list(Id(schema = 'Rob.ert',  table = 'Students;--')))
+
+  expect_error(dbUnquoteIdentifier(con, SQL('`Robert.`Students`')),
+               "^Can't unquote")
+})
+
+test_that("unquoting identifier - SQL without quotes", {
+  con <- mariadbDefault()
+  on.exit(dbDisconnect(con))
+
+  expect_equal(dbUnquoteIdentifier(con, SQL('Students')),
+               list(Id(table = 'Students')))
+
+  expect_equal(dbUnquoteIdentifier(con, SQL('Robert.Students')),
+               list(Id(schema = 'Robert', table = 'Students')))
+
+  expect_error(dbUnquoteIdentifier(con, SQL('Rob``ert.Students')),
+               "^Can't unquote")
+})
+
+test_that("unquoting identifier - Id", {
+  con <- mariadbDefault()
+  on.exit(dbDisconnect(con))
+
+  expect_equal(dbUnquoteIdentifier(con,
+                                   Id(schema = 'Robert', table = 'Students;--')),
+               list(Id(schema = 'Robert', table = 'Students;--')))
+})

--- a/tests/testthat/test-dbQuoteIdentifier.R
+++ b/tests/testthat/test-dbQuoteIdentifier.R
@@ -52,8 +52,6 @@ test_that("quoting errors", {
   con <- mariadbDefault()
   on.exit(dbDisconnect(con))
 
-  expect_error(dbQuoteIdentifier(con, Id(tabel = 'Robert')),
-               "components")
   expect_error(Id(table = 'Robert', table = 'Students;--'))
 })
 

--- a/tests/testthat/test-dbQuoteIdentifier.R
+++ b/tests/testthat/test-dbQuoteIdentifier.R
@@ -54,8 +54,7 @@ test_that("quoting errors", {
 
   expect_error(dbQuoteIdentifier(con, Id(tabel = 'Robert')),
                "components")
-  expect_error(dbQuoteIdentifier(con, Id(table = 'Robert', table = 'Students;--')),
-               "Duplicated")
+  expect_error(Id(table = 'Robert', table = 'Students;--'))
 })
 
 test_that("unquoting identifier - SQL with quotes", {

--- a/tests/testthat/test-dbWriteTable.R
+++ b/tests/testthat/test-dbWriteTable.R
@@ -14,7 +14,7 @@ test_that("dbWriteTable() throws error if constraint violated", {
 
   x <- data.frame(col1 = 1:10, col2 = letters[1:10])
 
-  dbWriteTable(con, "t1", x[1:3, ], overwrite = TRUE)
+  dbWriteTable(con, "t1", x[1:3, ], overwrite = TRUE, temporary = TRUE)
   dbExecute(con, "CREATE UNIQUE INDEX t1_c1_c2_idx ON t1(col1, col2(1))")
   expect_error(dbWriteTable(con, "t1", x, append = TRUE), "added 7 rows|Duplicate entry")
 })
@@ -25,7 +25,7 @@ test_that("dbAppendTable() throws error if constraint violated", {
 
   x <- data.frame(col1 = 1:10, col2 = letters[1:10])
 
-  dbWriteTable(con, "t1", x[1:3, ], overwrite = TRUE)
+  dbWriteTable(con, "t1", x[1:3, ], overwrite = TRUE, temporary = TRUE)
   dbExecute(con, "CREATE UNIQUE INDEX t1_c1_c2_idx ON t1(col1, col2(1))")
   expect_error(dbAppendTable(con, "t1", x), "added 7 rows|Duplicate entry")
 })


### PR DESCRIPTION
This allows quoting columns with `Id()` and `dbQuoteIdentifier()` and fixes the quoting of a schema, closes #254.

I've added tests for `dbQuoteIdentifier()` and `dbUnquoteIdentifier()` from [RPostgres](https://github.com/r-dbi/RPostgres/blob/c0aca74c0621bea663a3d7f4b20648ca5020a16e/tests/testthat/test-dbQuoteIdentifier.R), too.

``` r
library(RMariaDB)
con <- mariadbDefault()

# quote column
column_id <- Id(schema = "myschema", table = "mytable", column = "mycolumn")
dbQuoteIdentifier(con, column_id)
#> <SQL> `myschema`.`mytable`.`mycolumn`

# quote schema without dot
(schema_id <- dbQuoteIdentifier(con, Id(schema = "myschema")))
#> <SQL> `myschema`

# glue_sql() example: https://glue.tidyverse.org/reference/glue_sql.html
library(glue)
iris2 <- iris
colnames(iris2) <- gsub("[.]", "_", tolower(colnames(iris)))
DBI::dbWriteTable(con, "iris", iris2)

iris_db <- "iris"
nicknames_db <- "nicknames"

nicknames <- data.frame(
  species = c("setosa", "versicolor", "virginica"),
  nickname = c("Beachhead Iris", "Harlequin Blueflag", "Virginia Iris"),
  stringsAsFactors = FALSE
)

DBI::dbWriteTable(con, nicknames_db, nicknames)

cols <- list(
  DBI::Id(table = iris_db, column = "sepal_length"),
  DBI::Id(table = iris_db, column = "sepal_width"),
  DBI::Id(table = nicknames_db, column = "nickname")
)

iris_species <- DBI::Id(table = iris_db, column = "species")
nicknames_species <- DBI::Id(table = nicknames_db, column = "species")

query <- glue_sql("
  SELECT {`cols`*}
  FROM {`iris_db`}
  JOIN {`nicknames_db`}
  ON {`iris_species`}={`nicknames_species`}",
  .con = con
)
query
#> <SQL> SELECT `iris`.`sepal_length`, `iris`.`sepal_width`, `nicknames`.`nickname`
#> FROM `iris`
#> JOIN `nicknames`
#> ON `iris`.`species`=`nicknames`.`species`

DBI::dbGetQuery(con, query, n = 5)
#>   sepal_length sepal_width       nickname
#> 1          5.1         3.5 Beachhead Iris
#> 2          4.9         3.0 Beachhead Iris
#> 3          4.7         3.2 Beachhead Iris
#> 4          4.6         3.1 Beachhead Iris
#> 5          5.0         3.6 Beachhead Iris

dbExecute(con, glue_sql("DROP TABLE {`nicknames_db`}, iris", .con = con))
#> [1] 0

dbDisconnect(con)
```

