### PR TITLE
feat: Support `TIME` columns with subsecond precision

### DIFF
--- a/src/MariaRow.cpp
+++ b/src/MariaRow.cpp
@@ -192,12 +192,10 @@ double MariaRow::value_time(int j) {
     return NA_REAL;
 
   MYSQL_TIME* mytime = (MYSQL_TIME*) &buffers_[j][0];
-  return static_cast<double>(
-    static_cast<double>(mytime->hour) * 3600.0 +
-    static_cast<double>(mytime->minute) * 60.0 +
-    static_cast<double>(mytime->second) +
-    static_cast<double>(mytime->second_part) / 1000000.0
-  );
+  return static_cast<double>(mytime->hour) * 3600.0 +
+         static_cast<double>(mytime->minute) * 60.0 +
+         static_cast<double>(mytime->second) +
+         static_cast<double>(mytime->second_part) / 1000000.0;
 }
 
 void MariaRow::set_list_value(SEXP x, int i, int j) {

--- a/src/MariaRow.cpp
+++ b/src/MariaRow.cpp
@@ -192,7 +192,12 @@ double MariaRow::value_time(int j) {
     return NA_REAL;
 
   MYSQL_TIME* mytime = (MYSQL_TIME*) &buffers_[j][0];
-  return static_cast<double>(mytime->hour * 3600 + mytime->minute * 60 + mytime->second);
+  return static_cast<double>(
+    static_cast<double>(mytime->hour) * 3600.0 +
+    static_cast<double>(mytime->minute) * 60.0 +
+    static_cast<double>(mytime->second) +
+    static_cast<double>(mytime->second_part) / 1000000.0
+  );
 }
 
 void MariaRow::set_list_value(SEXP x, int i, int j) {

--- a/tests/testthat/test-queries.R
+++ b/tests/testthat/test-queries.R
@@ -44,6 +44,31 @@ test_that("fractional seconds in datetime (#170)", {
   dbDisconnect(con)
 })
 
+test_that("fractional seconds in time (#288)", {
+  con <- mariadbDefault()
+
+  time_str <- "09:30:01.123456"
+  time_hms <- hms::as_hms(time)
+  dataframe <- data.frame(Time = time_hms)
+
+  dbWriteTable(
+    con,
+    "my_table",
+    dataframe,
+    overwrite = TRUE,
+    temporary = TRUE,
+    field.types = c(Time = "time(6)"),
+    row.names = FALSE
+  )
+
+  out <- dbReadTable(con, "my_table")
+  expect_equal(dataframe, out)
+  expect_equal(out$Time, time_hms)
+  expect_equal(format(out$Time), time_str)  
+
+  dbDisconnect(con)
+})
+
 test_that("timezone argument (#184)", {
   skip_on_cran()
 

--- a/tests/testthat/test-queries.R
+++ b/tests/testthat/test-queries.R
@@ -48,7 +48,7 @@ test_that("fractional seconds in time (#288)", {
   con <- mariadbDefault()
 
   time_str <- "09:30:01.123456"
-  time_hms <- hms::as_hms(time)
+  time_hms <- hms::as_hms(time_str)
   dataframe <- data.frame(Time = time_hms)
 
   dbWriteTable(


### PR DESCRIPTION
Closes #288 

This PR fixes reading `TIME` column by preserving `second_part` which will otherwise be lost in a roundtrip.

- [x] Fix
- [x] Test case