### PR TITLE
fix: `dbConnection(groups = )` works as documented again, regression introduced in RMariaDB 1.3.0

### DIFF
--- a/src/DbConnection.cpp
+++ b/src/DbConnection.cpp
@@ -36,7 +36,7 @@ void DbConnection::connect(const cpp11::sexp& host, const cpp11::sexp& user,
   mysql_options(this->pConn_, MYSQL_OPT_LOCAL_INFILE, &local_infile);
   // Default to UTF-8
   mysql_options(this->pConn_, MYSQL_SET_CHARSET_NAME, "utf8mb4");
-  if (Rf_isNull(groups))
+  if (!Rf_isNull(groups))
     mysql_options(this->pConn_, MYSQL_READ_DEFAULT_GROUP,
                   cpp11::as_cpp<std::string>(groups).c_str());
   if (!Rf_isNull(default_file))


### PR DESCRIPTION
The `MYSQL_READ_DEFAULT_GROUP` option should be set only if the `groups` variable is *not* null.

Commit 219e5ca027c3970e3811974b7fca69091289ea54 introduced this bug.