### PR TITLE
feat: Support `dbSendStatement(immediate = TRUE)` and `dbExecute(immediate = TRUE)`, needs `CLIENT_MULTI_STATEMENTS`

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -52,8 +52,8 @@ init_logging <- function(log_level) {
   invisible(.Call(`_RMariaDB_init_logging`, log_level))
 }
 
-result_create <- function(con, sql, is_statement) {
-  .Call(`_RMariaDB_result_create`, con, sql, is_statement)
+result_create <- function(con, sql, is_statement, immediate) {
+  .Call(`_RMariaDB_result_create`, con, sql, is_statement, immediate)
 }
 
 result_release <- function(res) {

--- a/R/dbFetch_MariaDBResult.R
+++ b/R/dbFetch_MariaDBResult.R
@@ -8,16 +8,20 @@
 #' [dbSendStatement()] serves as a counterpart to [dbSendQuery()], while
 #' [dbExecute()] corresponds to [dbGetQuery()].
 #'
-#' @param conn an [MariaDBConnection-class] object.
-#' @param res A  [MariaDBResult-class] object.
+#' @param conn A [MariaDBConnection-class] object.
+#' @param res A [MariaDBResult-class] object.
 #' @inheritParams DBI::sqlRownamesToColumn
 #' @param n Number of rows to retrieve. Use -1 to retrieve all rows.
 #' @param params A list of query parameters to be substituted into
 #'   a parameterised query.
-#' @param statement a character vector of length one specifying the SQL
+#' @param statement A character vector of length one specifying the SQL
 #'   statement that should be executed.  Only a single SQL statement should be
 #'   provided.
 #' @param ... Unused. Needed for compatibility with generic.
+#' @param immediate If TRUE, uses the `mysql_real_query()` API
+#'   instead of `mysql_stmt_init()`.
+#'   This allows passing multiple statements (with [CLIENT_MULTI_STATEMENTS])
+#'   and turns off the ability to pass parameters.
 #' @examples
 #' if (mariadbHasDefault()) {
 #'   con <- dbConnect(RMariaDB::MariaDB(), dbname = "test")

--- a/R/dbSendQuery_MariaDBConnection_character.R
+++ b/R/dbSendQuery_MariaDBConnection_character.R
@@ -1,7 +1,9 @@
 #' @rdname query
 #' @usage NULL
-dbSendQuery_MariaDBConnection_character <- function(conn, statement, params = NULL, ...) {
-  dbSend(conn, statement, params, is_statement = FALSE)
+dbSendQuery_MariaDBConnection_character <- function(conn, statement, params = NULL, ..., immediate = FALSE) {
+  # immediate = TRUE not supported
+  # Can't raise a warning here due to a test in DBItest
+  dbSend(conn, statement, params, is_statement = FALSE, immediate = FALSE)
 }
 
 #' @rdname query

--- a/R/dbSendStatement_MariaDBConnection_character.R
+++ b/R/dbSendStatement_MariaDBConnection_character.R
@@ -1,7 +1,7 @@
 #' @rdname query
 #' @usage NULL
-dbSendStatement_MariaDBConnection_character <- function(conn, statement, params = NULL, ...) {
-  dbSend(conn, statement, params, is_statement = TRUE)
+dbSendStatement_MariaDBConnection_character <- function(conn, statement, params = NULL, ..., immediate = FALSE) {
+  dbSend(conn, statement, params, is_statement = TRUE, immediate)
 }
 
 #' @rdname query

--- a/R/query.R
+++ b/R/query.R
@@ -39,12 +39,12 @@ fix_blob <- function(ret) {
   ret
 }
 
-dbSend <- function(conn, statement, params = NULL, is_statement) {
+dbSend <- function(conn, statement, params = NULL, is_statement, immediate) {
   statement <- enc2utf8(statement)
 
   rs <- new("MariaDBResult",
     sql = statement,
-    ptr = result_create(conn@ptr, statement, is_statement),
+    ptr = result_create(conn@ptr, statement, is_statement, immediate),
     bigint = conn@bigint,
     conn = conn
   )

--- a/man/query.Rd
+++ b/man/query.Rd
@@ -28,12 +28,12 @@
 
 \S4method{dbGetStatement}{MariaDBResult}(res, ...)
 
-\S4method{dbSendQuery}{MariaDBConnection,character}(conn, statement, params = NULL, ...)
+\S4method{dbSendQuery}{MariaDBConnection,character}(conn, statement, params = NULL, ..., immediate = FALSE)
 
-\S4method{dbSendStatement}{MariaDBConnection,character}(conn, statement, params = NULL, ...)
+\S4method{dbSendStatement}{MariaDBConnection,character}(conn, statement, params = NULL, ..., immediate = FALSE)
 }
 \arguments{
-\item{res}{A  \linkS4class{MariaDBResult} object.}
+\item{res}{A \linkS4class{MariaDBResult} object.}
 
 \item{params}{A list of query parameters to be substituted into
 a parameterised query.}
@@ -53,11 +53,16 @@ default name.
 
 For backward compatibility, \code{NULL} is equivalent to \code{FALSE}.}
 
-\item{conn}{an \linkS4class{MariaDBConnection} object.}
+\item{conn}{A \linkS4class{MariaDBConnection} object.}
 
-\item{statement}{a character vector of length one specifying the SQL
+\item{statement}{A character vector of length one specifying the SQL
 statement that should be executed.  Only a single SQL statement should be
 provided.}
+
+\item{immediate}{If TRUE, uses the \code{mysql_real_query()} API
+instead of \code{mysql_stmt_init()}.
+This allows passing multiple statements (with \link{CLIENT_MULTI_STATEMENTS})
+and turns off the ability to pass parameters.}
 }
 \description{
 To retrieve results a chunk at a time, use \code{\link[=dbSendQuery]{dbSendQuery()}},

--- a/src/DbConnection.cpp
+++ b/src/DbConnection.cpp
@@ -185,9 +185,11 @@ bool DbConnection::exec(const std::string& sql) {
   if (mysql_real_query(pConn_, sql.data(), sql.size()) != 0)
     cpp11::stop("Error executing query: %s", mysql_error(pConn_));
 
-  MYSQL_RES* res = mysql_store_result(pConn_);
-  if (res != NULL)
-    mysql_free_result(res);
+  do {
+    MYSQL_RES* res = mysql_store_result(pConn_);
+    if (res != NULL)
+      mysql_free_result(res);
+  } while (mysql_next_result(pConn_) == 0);
 
   autocommit();
 

--- a/src/MariaResult.cpp
+++ b/src/MariaResult.cpp
@@ -6,25 +6,35 @@
 
 // Construction ////////////////////////////////////////////////////////////////
 
-MariaResult::MariaResult(const DbConnectionPtr& pConn, const std::string& sql, bool is_statement) :
+MariaResult::MariaResult(const DbConnectionPtr& pConn, const std::string& sql, bool is_statement, bool immediate) :
   DbResult(pConn)
 {
-  boost::scoped_ptr<MariaResultImpl> res(new MariaResultPrep(pConn, is_statement));
-  try {
-    res->send_query(sql);
+  boost::scoped_ptr<MariaResultImpl> res;
+  if (!immediate) {
+    try {
+      res.reset(new MariaResultPrep(pConn, is_statement));
+      res->send_query(sql);
+    }
+    catch (const MariaResultPrep::UnsupportedPS& e) {
+      immediate = TRUE;
+      res.reset(NULL);
+    }
   }
-  catch (const MariaResultPrep::UnsupportedPS& e) {
-    res.reset(NULL);
+
+  // Resetting the immediate flag in the catch block above
+  if (immediate) {
     // is_statement info might be worthwhile to pass to simple queries as well
     res.reset(new MariaResultSimple(pConn, is_statement));
     res->send_query(sql);
   }
 
+  BOOST_ASSERT(res.get());
+
   res.swap(impl);
 }
 
-DbResult* MariaResult::create_and_send_query(const DbConnectionPtr& con, const std::string& sql, bool is_statement) {
-  return new MariaResult(con, sql, is_statement);
+DbResult* MariaResult::create_and_send_query(const DbConnectionPtr& con, const std::string& sql, bool is_statement, bool immediate) {
+  return new MariaResult(con, sql, is_statement, immediate);
 }
 
 // Publics /////////////////////////////////////////////////////////////////////

--- a/src/MariaResult.h
+++ b/src/MariaResult.h
@@ -8,10 +8,10 @@
 
 class MariaResult : public DbResult {
 protected:
-  MariaResult(const DbConnectionPtr& pConn, const std::string& sql, bool is_statement);
+  MariaResult(const DbConnectionPtr& pConn, const std::string& sql, bool is_statement, bool immediate);
 
 public:
-  static DbResult* create_and_send_query(const DbConnectionPtr& con, const std::string& sql, bool is_statement);
+  static DbResult* create_and_send_query(const DbConnectionPtr& con, const std::string& sql, bool is_statement, bool immediate);
 
 public:
   void close();

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -104,10 +104,10 @@ extern "C" SEXP _RMariaDB_init_logging(SEXP log_level) {
   END_CPP11
 }
 // result.cpp
-cpp11::external_pointer<DbResult> result_create(cpp11::external_pointer<DbConnectionPtr> con, std::string sql, bool is_statement);
-extern "C" SEXP _RMariaDB_result_create(SEXP con, SEXP sql, SEXP is_statement) {
+cpp11::external_pointer<DbResult> result_create(cpp11::external_pointer<DbConnectionPtr> con, std::string sql, bool is_statement, bool immediate);
+extern "C" SEXP _RMariaDB_result_create(SEXP con, SEXP sql, SEXP is_statement, SEXP immediate) {
   BEGIN_CPP11
-    return cpp11::as_sexp(result_create(cpp11::as_cpp<cpp11::decay_t<cpp11::external_pointer<DbConnectionPtr>>>(con), cpp11::as_cpp<cpp11::decay_t<std::string>>(sql), cpp11::as_cpp<cpp11::decay_t<bool>>(is_statement)));
+    return cpp11::as_sexp(result_create(cpp11::as_cpp<cpp11::decay_t<cpp11::external_pointer<DbConnectionPtr>>>(con), cpp11::as_cpp<cpp11::decay_t<std::string>>(sql), cpp11::as_cpp<cpp11::decay_t<bool>>(is_statement), cpp11::as_cpp<cpp11::decay_t<bool>>(immediate)));
   END_CPP11
 }
 // result.cpp
@@ -185,7 +185,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_RMariaDB_init_logging",                 (DL_FUNC) &_RMariaDB_init_logging,                  1},
     {"_RMariaDB_result_bind",                  (DL_FUNC) &_RMariaDB_result_bind,                   2},
     {"_RMariaDB_result_column_info",           (DL_FUNC) &_RMariaDB_result_column_info,            1},
-    {"_RMariaDB_result_create",                (DL_FUNC) &_RMariaDB_result_create,                 3},
+    {"_RMariaDB_result_create",                (DL_FUNC) &_RMariaDB_result_create,                 4},
     {"_RMariaDB_result_fetch",                 (DL_FUNC) &_RMariaDB_result_fetch,                  2},
     {"_RMariaDB_result_has_completed",         (DL_FUNC) &_RMariaDB_result_has_completed,          1},
     {"_RMariaDB_result_release",               (DL_FUNC) &_RMariaDB_result_release,                1},

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -5,9 +5,9 @@
 
 [[cpp11::register]]
 cpp11::external_pointer<DbResult>
-result_create(cpp11::external_pointer<DbConnectionPtr> con, std::string sql, bool is_statement = false) {
+result_create(cpp11::external_pointer<DbConnectionPtr> con, std::string sql, bool is_statement = false, bool immediate = false) {
   (*con)->check_connection();
-  DbResult* res = MariaResult::create_and_send_query(*con, sql, is_statement);
+  DbResult* res = MariaResult::create_and_send_query(*con, sql, is_statement, immediate);
   return cpp11::external_pointer<DbResult>(res, true);
 }
 


### PR DESCRIPTION
Closes #147.