### PR TITLE
fix: `dbConnect()` can enable SSL based on `client_flag` again

### DIFF
--- a/src/DbConnection.cpp
+++ b/src/DbConnection.cpp
@@ -43,6 +43,15 @@ void DbConnection::connect(const cpp11::sexp& host, const cpp11::sexp& user,
     mysql_options(this->pConn_, MYSQL_READ_DEFAULT_FILE,
                   cpp11::as_cpp<std::string>(default_file).c_str());
 
+  // Set SSL options
+  if (client_flag & CLIENT_SSL) {
+    my_bool use_ssl_ = 1;
+    mysql_options(this->pConn_, MYSQL_OPT_SSL_ENFORCE, (void *)&use_ssl_);
+  }
+  if (client_flag & CLIENT_SSL_VERIFY_SERVER_CERT) {
+    my_bool verify_server_cert_ = 1;
+    mysql_options(this->pConn_, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, (void *)&verify_server_cert_);
+  }
   if (!Rf_isNull(ssl_key)) {
     mysql_options(this->pConn_, MYSQL_OPT_SSL_KEY,    cpp11::as_cpp<std::string>(ssl_key).c_str());
   }


### PR DESCRIPTION
Allows connection to proceed when SSL is required without having to rely on a default file or group with ssl-enforce=1.