### PR TITLE
fix: `dbQuoteIdentifier()` removes the `def` catalog component again, regression introduced in RMariaDB 1.3.1

### DIFF
--- a/R/dbQuoteIdentifier_MariaDBConnection_Id.R
+++ b/R/dbQuoteIdentifier_MariaDBConnection_Id.R
@@ -1,7 +1,12 @@
 #' @name mariadb-quoting
 #' @usage NULL
 dbQuoteIdentifier_MariaDBConnection_Id <- function(conn, x, ...) {
-  SQL(paste0(dbQuoteIdentifier(conn, x@name), collapse = "."))
+  unqouted_name <- x@name
+  if (length(unqouted_name) == 3 && unqouted_name[[1]] == "def") {
+    unqouted_name <- unqouted_name[-1]
+  }
+
+  SQL(paste0(dbQuoteIdentifier(conn, unqouted_name), collapse = "."))
 }
 
 #' @rdname mariadb-quoting

--- a/tests/testthat/test-dbQuoteIdentifier_MariaDBConnection_Id.R
+++ b/tests/testthat/test-dbQuoteIdentifier_MariaDBConnection_Id.R
@@ -1,0 +1,9 @@
+test_that("dbQuoteIdentifier() and def", {
+  skip_if_not(mariadbHasDefault())
+
+  conn <- withr::local_db_connection(mariadbDefault())
+
+  expect_equal(dbQuoteIdentifier(conn, Id("def", "a", "b")), SQL("`a`.`b`"))
+  expect_equal(dbQuoteIdentifier(conn, Id("a", "b")), SQL("`a`.`b`"))
+  expect_equal(dbQuoteIdentifier(conn, Id("def", "a")), SQL("`def`.`a`"))
+})


### PR DESCRIPTION
Closes #337.