### PR TITLE
fledge: CRAN release v1.3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RMariaDB
 Title: Database Interface and MariaDB Driver
-Version: 1.3.2.9901
+Version: 1.3.3
 Authors@R: c(
     person("Kirill", "Müller", , "kirill@cynkra.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1416-3412")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,13 +10,6 @@
 
 - Add back SSL support for MariaDB 5.5.68 (@d-hansen, #336, #338).
 
-## Uncategorized
-
-- CRAN comments.
-- Bump version to 1.3.2.9900.
-- Add rhub.
-- NEWS.
-
 
 # RMariaDB 1.3.2 (2024-05-26)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,17 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RMariaDB 1.3.2.9901 (2024-11-18)
-
-- CRAN comments.
-
-- Bump version to 1.3.2.9900.
-
-- Add rhub.
-
-- NEWS.
-
-
-# RMariaDB 1.3.2.9900 (2024-11-18)
+# RMariaDB 1.3.3 (2024-11-18)
 
 ## Bug fixes
 
@@ -20,6 +9,13 @@
 ## Features
 
 - Add back SSL support for MariaDB 5.5.68 (@d-hansen, #336, #338).
+
+## Uncategorized
+
+- CRAN comments.
+- Bump version to 1.3.2.9900.
+- Add rhub.
+- NEWS.
 
 
 # RMariaDB 1.3.2 (2024-05-26)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-RMariaDB 1.3.2.9900
+RMariaDB 1.3.3
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2024-11-18, problems found: https://cran.r-project.org/web/checks/check_results_RMariaDB.html
- [x] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64
     Found the following Rd file(s) with Rd \link{} targets missing package
     anchors:
     Client-flags.Rd: dbConnect
     dbConnect-MariaDBDriver-method.Rd: dbWriteTable, dbAppendTable
     mariadb-tables.Rd: dbConnect
     query.Rd: dbSendQuery, dbFetch, dbClearResult, dbGetQuery,
     dbSendStatement, dbExecute
     Please provide package anchors for all Rd \link{} targets not in the
     package itself and the base packages.

Check results at: https://cran.r-project.org/web/checks/check_results_RMariaDB.html

## Action items

- [x] Review PR
- [x] Await successful CI/CD run
- [x] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`