### PR TITLE
fledge: CRAN release v1.3.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RMariaDB
 Title: Database Interface and MariaDB Driver
-Version: 1.3.3.9003
+Version: 1.3.4
 Authors@R: c(
     person("Kirill", "Müller", , "kirill@cynkra.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1416-3412")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RMariaDB 1.3.3.9003 (2025-02-09)
+# RMariaDB 1.3.4 (2025-02-11)
+
+## Windows
+
+- Use mariadbclient from Rtools if available (#383).
+
+## Bug fixes
+
+- Adjust datetime format in `dbQuoteLiteral()` for `MySQLConnection` (@jjaeschke, #353).
 
 ## Continuous integration
 
@@ -9,18 +17,6 @@
 - Fix typo.
 
 - Add old Windows.
-
-
-# RMariaDB 1.3.3.9002 (2025-02-08)
-
-## Windows
-
-- Use mariadbclient from Rtools if available (#383).
-
-
-# RMariaDB 1.3.3.9001 (2024-12-12)
-
-## Continuous integration
 
 - Avoid failure in fledge workflow if no changes (#378).
 
@@ -40,20 +36,11 @@
 
 - Use Ubuntu 24.04 and styler PR (#356).
 
+- Correctly detect branch protection (#354).
+
 ## Uncategorized
 
 - Ci: Fix macOS (#16) (#357).
-
-
-# RMariaDB 1.3.3.9000 (2024-11-22)
-
-## Bug fixes
-
-- Adjust datetime format in `dbQuoteLiteral()` for `MySQLConnection` (@jjaeschke, #353).
-
-## Continuous integration
-
-- Correctly detect branch protection (#354).
 
 
 # RMariaDB 1.3.3 (2024-11-18)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-RMariaDB 1.3.3
+RMariaDB 1.3.4
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-02-11, problems found: https://cran.r-project.org/web/checks/check_results_RMariaDB.html
- [ ] other_issue: NA
See: <https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/RMariaDB.out>

Check results at: https://cran.r-project.org/web/checks/check_results_RMariaDB.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`