### PR TITLE
fledge: CRAN release v1.3.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RMariaDB
 Title: Database Interface and MariaDB Driver
-Version: 1.3.3.9900
+Version: 1.3.4
 Authors@R: c(
     person("Kirill", "Müller", , "kirill@cynkra.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1416-3412")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,38 +10,6 @@
 
 - Adjust datetime format in `dbQuoteLiteral()` for `MySQLConnection` (@jjaeschke, #353).
 
-## Continuous integration
-
-- Fix.
-
-- Fix typo.
-
-- Add old Windows.
-
-- Avoid failure in fledge workflow if no changes (#378).
-
-- Fetch tags for fledge workflow to avoid unnecessary NEWS entries (#376).
-
-- Use larger retry count for lock-threads workflow (#374).
-
-- Add `mariadb_config` to `$PATH` on macOS.
-
-- Ignore errors when removing pkg-config on macOS (#364).
-
-- Explicit permissions (#362).
-
-- Use styler from main branch (#360).
-
-- Need to install R on Ubuntu 24.04 (#358).
-
-- Use Ubuntu 24.04 and styler PR (#356).
-
-- Correctly detect branch protection (#354).
-
-## Uncategorized
-
-- Ci: Fix macOS (#16) (#357).
-
 
 # RMariaDB 1.3.3 (2024-11-18)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RMariaDB 1.3.3.9900 (2025-02-24)
+# RMariaDB 1.3.4 (2025-02-24)
 
 ## Windows
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-RMariaDB 1.3.3.9900
+RMariaDB 1.3.4
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-02-24, problems found: https://cran.r-project.org/web/checks/check_results_RMariaDB.html
- [ ] WARN: r-devel-linux-x86_64-fedora-clang
     Found the following significant warnings:
     /data/gannet/ripley/R/test-clang/cpp11/include/cpp11/R.hpp:52:31: warning: identifier '_xl' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     /data/gannet/ripley/R/test-clang/cpp11/include/cpp11/named_arg.hpp:42:29: warning: identifier '_nm' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     See ‘/data/gannet/ripley/R/packages/tests-clang/RMariaDB.Rcheck/00install.out’ for details.
     * used C++ compiler: ‘clang version 20.1.0-rc2’
- [ ] other_issue: NA
See: <https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/RMariaDB.out>

Check results at: https://cran.r-project.org/web/checks/check_results_RMariaDB.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`