### PR TITLE
fix: promote unsigned integers to double to prevent overflow

### DIFF
--- a/R/MariaDBConnection.R
+++ b/R/MariaDBConnection.R
@@ -23,6 +23,7 @@ MariaDBConnection <- setClass("MariaDBConnection",
     db = "character",
     load_data_local_infile = "logical",
     bigint = "character",
+    unsigned_int = "character",
     timezone = "character",
     timezone_out = "character"
   )

--- a/R/MariaDBResult.R
+++ b/R/MariaDBResult.R
@@ -11,6 +11,7 @@ setClass("MariaDBResult",
     ptr = "externalptr",
     sql = "character",
     bigint = "character",
+    unsigned_int = "character",
     conn = "MariaDBConnection"
   )
 )

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -83,3 +83,7 @@ result_rows_affected <- function(res) {
 result_column_info <- function(res) {
   .Call(`_RMariaDB_result_column_info`, res)
 }
+
+result_is_unsigned_int <- function(res) {
+  .Call(`_RMariaDB_result_is_unsigned_int`, res)
+}

--- a/R/dbConnect_MariaDBDriver.R
+++ b/R/dbConnect_MariaDBDriver.R
@@ -64,10 +64,12 @@
 #'   for recent versions of MySQL Server.
 #' @param bigint The R type that 64-bit integer types should be mapped to,
 #'   default is [bit64::integer64], which allows the full range of 64 bit
-#'   integers.
+#'   integers. `INT UNSIGNED` columns are governed by `unsigned_int`, not this
+#'   argument.
 #' @param unsigned_int The R type that `INT UNSIGNED` columns should be mapped
 #'   to, default is [bit64::integer64], which safely represents the full
-#'   unsigned 32-bit range.
+#'   unsigned 32-bit range. Does not affect `BIGINT UNSIGNED` columns, which
+#'   are governed by `bigint`.
 #' @param timeout Connection timeout, in seconds. Use `Inf` or a negative value
 #'   for no timeout.
 #' @param timezone (optional) time zone for the connection,

--- a/R/dbConnect_MariaDBDriver.R
+++ b/R/dbConnect_MariaDBDriver.R
@@ -65,6 +65,9 @@
 #' @param bigint The R type that 64-bit integer types should be mapped to,
 #'   default is [bit64::integer64], which allows the full range of 64 bit
 #'   integers.
+#' @param unsigned_int The R type that `INT UNSIGNED` columns should be mapped
+#'   to, default is [bit64::integer64], which safely represents the full
+#'   unsigned 32-bit range.
 #' @param timeout Connection timeout, in seconds. Use `Inf` or a negative value
 #'   for no timeout.
 #' @param timezone (optional) time zone for the connection,
@@ -146,6 +149,7 @@ dbConnect_MariaDBDriver <- function(
     groups = NULL,
     load_data_local_infile = FALSE,
     bigint = c("integer64", "integer", "numeric", "character"),
+    unsigned_int = c("integer64", "integer", "numeric", "character"),
     timeout = 10,
     timezone = "+00:00",
     timezone_out = NULL,
@@ -153,6 +157,7 @@ dbConnect_MariaDBDriver <- function(
     mysql = NULL) {
   #
   bigint <- match.arg(bigint)
+  unsigned_int <- match.arg(unsigned_int)
 
   if (is.infinite(timeout)) {
     timeout <- -1L
@@ -224,7 +229,8 @@ dbConnect_MariaDBDriver <- function(
     host = info$host,
     db = info$dbname,
     load_data_local_infile = isTRUE(load_data_local_infile),
-    bigint = bigint
+    bigint = bigint,
+    unsigned_int = unsigned_int
   )
 
   on.exit(dbDisconnect(conn))

--- a/R/dbFetch_MariaDBResult.R
+++ b/R/dbFetch_MariaDBResult.R
@@ -47,7 +47,9 @@ dbFetch_MariaDBResult <- function(res, n = -1, ..., row.names = FALSE) {
   if (is.infinite(n)) n <- -1
   if (trunc(n) != n) stopc("n must be a whole number")
   ret <- result_fetch(res@ptr, n = n)
-  ret <- convert_bigint(ret, res@bigint)
+  is_unsigned_int <- result_is_unsigned_int(res@ptr)
+  ret <- convert_bigint(ret, res@bigint, is_unsigned_int)
+  ret <- convert_unsigned_int(ret, res@unsigned_int, is_unsigned_int)
   ret <- fix_timezone(ret, res@conn)
   ret <- fix_blob(ret)
   ret <- sqlColumnToRownames(ret, row.names)

--- a/R/query.R
+++ b/R/query.R
@@ -46,6 +46,7 @@ dbSend <- function(conn, statement, params = NULL, is_statement, immediate) {
     sql = statement,
     ptr = result_create(conn@ptr, statement, is_statement, immediate),
     bigint = conn@bigint,
+    unsigned_int = conn@unsigned_int,
     conn = conn
   )
 

--- a/R/query.R
+++ b/R/query.R
@@ -2,9 +2,9 @@
 #' @include MariaDBResult.R
 NULL
 
-convert_bigint <- function(df, bigint) {
+convert_bigint <- function(df, bigint, is_unsigned_int = rep(FALSE, length(df))) {
   if (bigint == "integer64") return(df)
-  is_int64 <- which(vlapply(df, inherits, "integer64"))
+  is_int64 <- which(vlapply(df, inherits, "integer64") & !is_unsigned_int)
   if (length(is_int64) == 0) return(df)
 
   as_bigint <- switch(bigint,
@@ -14,6 +14,21 @@ convert_bigint <- function(df, bigint) {
   )
 
   df[is_int64] <- suppressWarnings(lapply(df[is_int64], as_bigint))
+  df
+}
+
+convert_unsigned_int <- function(df, unsigned_int, is_unsigned_int) {
+  if (unsigned_int == "integer64") return(df)
+  idx <- which(is_unsigned_int)
+  if (length(idx) == 0) return(df)
+
+  as_target <- switch(unsigned_int,
+    integer = as.integer,
+    numeric = as.numeric,
+    character = as.character
+  )
+
+  df[idx] <- suppressWarnings(lapply(df[idx], as_target))
   df
 }
 

--- a/man/dbConnect-MariaDBDriver-method.Rd
+++ b/man/dbConnect-MariaDBDriver-method.Rd
@@ -93,11 +93,13 @@ for recent versions of MySQL Server.}
 
 \item{bigint}{The R type that 64-bit integer types should be mapped to,
 default is \link[bit64:integer64]{bit64::integer64}, which allows the full range of 64 bit
-integers.}
+integers. \verb{INT UNSIGNED} columns are governed by \code{unsigned_int}, not this
+argument.}
 
 \item{unsigned_int}{The R type that \verb{INT UNSIGNED} columns should be mapped
 to, default is \link[bit64:integer64]{bit64::integer64}, which safely represents the full
-unsigned 32-bit range.}
+unsigned 32-bit range. Does not affect \verb{BIGINT UNSIGNED} columns, which
+are governed by \code{bigint}.}
 
 \item{timeout}{Connection timeout, in seconds. Use \code{Inf} or a negative value
 for no timeout.}

--- a/man/dbConnect-MariaDBDriver-method.Rd
+++ b/man/dbConnect-MariaDBDriver-method.Rd
@@ -28,6 +28,7 @@ MariaDB()
   groups = NULL,
   load_data_local_infile = FALSE,
   bigint = c("integer64", "integer", "numeric", "character"),
+  unsigned_int = c("integer64", "integer", "numeric", "character"),
   timeout = 10,
   timezone = "+00:00",
   timezone_out = NULL,
@@ -93,6 +94,10 @@ for recent versions of MySQL Server.}
 \item{bigint}{The R type that 64-bit integer types should be mapped to,
 default is \link[bit64:integer64]{bit64::integer64}, which allows the full range of 64 bit
 integers.}
+
+\item{unsigned_int}{The R type that \verb{INT UNSIGNED} columns should be mapped
+to, default is \link[bit64:integer64]{bit64::integer64}, which safely represents the full
+unsigned 32-bit range.}
 
 \item{timeout}{Connection timeout, in seconds. Use \code{Inf} or a negative value
 for no timeout.}

--- a/src/DbResult.cpp
+++ b/src/DbResult.cpp
@@ -64,6 +64,10 @@ cpp11::list DbResult::get_column_info() {
   return out;
 }
 
+std::vector<bool> DbResult::get_is_unsigned_int() {
+  return impl->get_is_unsigned_int();
+}
+
 void DbResult::close() {
   // Called from destructor
   if (impl) {

--- a/src/DbResult.h
+++ b/src/DbResult.h
@@ -37,6 +37,8 @@ public:
 
   cpp11::list get_column_info();
 
+  std::vector<bool> get_is_unsigned_int();
+
 private:
   void validate_params(const cpp11::list& params) const;
 };

--- a/src/MariaResultImpl.h
+++ b/src/MariaResultImpl.h
@@ -13,6 +13,7 @@ public:
   virtual void bind(const cpp11::list& params) = 0;
 
   virtual cpp11::list get_column_info() = 0;
+  virtual std::vector<bool> get_is_unsigned_int() const = 0;
 
   virtual cpp11::list fetch(int n_max = -1) = 0;
 

--- a/src/MariaResultPrep.cpp
+++ b/src/MariaResultPrep.cpp
@@ -257,5 +257,12 @@ void MariaResultPrep::cache_metadata() {
       is_unsigned
     );
     types_.push_back(type);
+    is_unsigned_int_.push_back(
+      fields[i].type == MYSQL_TYPE_LONG && is_unsigned
+    );
   }
+}
+
+std::vector<bool> MariaResultPrep::get_is_unsigned_int() const {
+  return is_unsigned_int_;
 }

--- a/src/MariaResultPrep.cpp
+++ b/src/MariaResultPrep.cpp
@@ -249,8 +249,13 @@ void MariaResultPrep::cache_metadata() {
 
     bool binary = fields[i].charsetnr == 63;
     bool length1 = fields[i].length == 1;
-    MariaFieldType type =
-      variable_type_from_field_type(fields[i].type, binary, length1);
+    bool is_unsigned = (fields[i].flags & UNSIGNED_FLAG) != 0;
+    MariaFieldType type = variable_type_from_field_type(
+      fields[i].type,
+      binary,
+      length1,
+      is_unsigned
+    );
     types_.push_back(type);
   }
 }

--- a/src/MariaResultPrep.h
+++ b/src/MariaResultPrep.h
@@ -26,6 +26,7 @@ class MariaResultPrep : boost::noncopyable, public MariaResultImpl {
 
   std::vector<MariaFieldType> types_;
   std::vector<std::string> names_;
+  std::vector<bool> is_unsigned_int_;
   MariaBinding bindingInput_;
   MariaRow bindingOutput_;
 
@@ -40,6 +41,7 @@ public:
   virtual void bind(const cpp11::list& params);
 
   virtual cpp11::list get_column_info();
+  virtual std::vector<bool> get_is_unsigned_int() const;
 
   virtual cpp11::list fetch(int n_max = -1);
 

--- a/src/MariaResultSimple.cpp
+++ b/src/MariaResultSimple.cpp
@@ -59,6 +59,11 @@ bool MariaResultSimple::complete() const {
   return true;
 }
 
+std::vector<bool> MariaResultSimple::get_is_unsigned_int() const {
+  // Simple path never returns typed rows; no column metadata to report.
+  return std::vector<bool>();
+}
+
 void MariaResultSimple::exec(const std::string& sql) {
   pConn_->exec(sql);
 }

--- a/src/MariaResultSimple.h
+++ b/src/MariaResultSimple.h
@@ -26,6 +26,7 @@ public:
   virtual void bind(const cpp11::list& params);
 
   virtual cpp11::list get_column_info();
+  virtual std::vector<bool> get_is_unsigned_int() const;
 
   virtual cpp11::list fetch(int n_max = -1);
 

--- a/src/MariaTypes.cpp
+++ b/src/MariaTypes.cpp
@@ -7,8 +7,16 @@ bool all_raw(SEXP x);
 MariaFieldType variable_type_from_field_type(
   enum_field_types type,
   bool binary,
-  bool length1
+  bool length1,
+  bool is_unsigned
 ) {
+  // INT UNSIGNED (uint32) overflows R's signed int32; widen to int64.
+  // Narrower unsigned ints fit in int32; BIGINT UNSIGNED is handled by
+  // MYSQL_TYPE_LONGLONG below.
+  if (type == MYSQL_TYPE_LONG && is_unsigned) {
+    return MY_INT64;
+  }
+
   switch (type) {
   case MYSQL_TYPE_TINY:
   case MYSQL_TYPE_SHORT:

--- a/src/MariaTypes.h
+++ b/src/MariaTypes.h
@@ -16,7 +16,8 @@ enum MariaFieldType {
 MariaFieldType variable_type_from_field_type(
   enum_field_types type,
   bool binary,
-  bool length1
+  bool length1,
+  bool is_unsigned
 );
 std::string type_name(MariaFieldType type);
 SEXPTYPE type_sexp(MariaFieldType type);

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -160,6 +160,13 @@ extern "C" SEXP _RMariaDB_result_column_info(SEXP res) {
     return cpp11::as_sexp(result_column_info(cpp11::as_cpp<cpp11::decay_t<DbResult*>>(res)));
   END_CPP11
 }
+// result.cpp
+cpp11::logicals result_is_unsigned_int(DbResult* res);
+extern "C" SEXP _RMariaDB_result_is_unsigned_int(SEXP res) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(result_is_unsigned_int(cpp11::as_cpp<cpp11::decay_t<DbResult*>>(res)));
+  END_CPP11
+}
 
 extern "C" {
 static const R_CallMethodDef CallEntries[] = {
@@ -179,6 +186,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_RMariaDB_result_create",                (DL_FUNC) &_RMariaDB_result_create,                 4},
     {"_RMariaDB_result_fetch",                 (DL_FUNC) &_RMariaDB_result_fetch,                  2},
     {"_RMariaDB_result_has_completed",         (DL_FUNC) &_RMariaDB_result_has_completed,          1},
+    {"_RMariaDB_result_is_unsigned_int",       (DL_FUNC) &_RMariaDB_result_is_unsigned_int,        1},
     {"_RMariaDB_result_release",               (DL_FUNC) &_RMariaDB_result_release,                1},
     {"_RMariaDB_result_rows_affected",         (DL_FUNC) &_RMariaDB_result_rows_affected,          1},
     {"_RMariaDB_result_rows_fetched",          (DL_FUNC) &_RMariaDB_result_rows_fetched,           1},

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -56,3 +56,13 @@ int result_rows_affected(DbResult* res) {
 cpp11::list result_column_info(DbResult* res) {
   return res->get_column_info();
 }
+
+[[cpp11::register]]
+cpp11::logicals result_is_unsigned_int(DbResult* res) {
+  std::vector<bool> flags = res->get_is_unsigned_int();
+  cpp11::writable::logicals out(static_cast<R_xlen_t>(flags.size()));
+  for (size_t i = 0; i < flags.size(); ++i) {
+    out[static_cast<R_xlen_t>(i)] = static_cast<bool>(flags[i]);
+  }
+  return out;
+}

--- a/tests/testthat/test-unsigned-int.R
+++ b/tests/testthat/test-unsigned-int.R
@@ -14,3 +14,24 @@ test_that("unsigned_int defaults to integer64 and preserves values above 2^31", 
     c(NA, "0", "1", "2147483647", "2147483648", "4294967295")
   )
 })
+
+test_that("unsigned_int = 'numeric' returns doubles", {
+  skip_if_not(mariadbHasDefault())
+  con <- dbConnect(
+    MariaDB(),
+    default.file = "~/.my.cnf",
+    group = "rs-dbi",
+    dbname = "test",
+    unsigned_int = "numeric"
+  )
+  on.exit(dbDisconnect(con))
+
+  dbExecute(con, "CREATE TEMPORARY TABLE t_uint_num (x INT UNSIGNED)")
+  dbExecute(con, "INSERT INTO t_uint_num VALUES (0), (2147483648), (4294967295)")
+
+  out <- dbGetQuery(con, "SELECT x FROM t_uint_num ORDER BY x")
+
+  expect_type(out$x, "double")
+  expect_false(inherits(out$x, "integer64"))
+  expect_equal(out$x, c(0, 2147483648, 4294967295))
+})

--- a/tests/testthat/test-unsigned-int.R
+++ b/tests/testthat/test-unsigned-int.R
@@ -35,3 +35,88 @@ test_that("unsigned_int = 'numeric' returns doubles", {
   expect_false(inherits(out$x, "integer64"))
   expect_equal(out$x, c(0, 2147483648, 4294967295))
 })
+
+test_that("unsigned_int = 'integer' overflows values above 2^31 to NA", {
+  skip_if_not(mariadbHasDefault())
+  con <- dbConnect(
+    MariaDB(),
+    default.file = "~/.my.cnf",
+    group = "rs-dbi",
+    dbname = "test",
+    unsigned_int = "integer"
+  )
+  on.exit(dbDisconnect(con))
+
+  dbExecute(con, "CREATE TEMPORARY TABLE t_uint_int (x INT UNSIGNED)")
+  dbExecute(con, "INSERT INTO t_uint_int VALUES (0), (2147483647), (2147483648), (4294967295)")
+
+  out <- dbGetQuery(con, "SELECT x FROM t_uint_int ORDER BY x")
+
+  expect_type(out$x, "integer")
+  expect_equal(out$x, c(0L, 2147483647L, NA_integer_, NA_integer_))
+})
+
+test_that("unsigned_int = 'character' returns string representation", {
+  skip_if_not(mariadbHasDefault())
+  con <- dbConnect(
+    MariaDB(),
+    default.file = "~/.my.cnf",
+    group = "rs-dbi",
+    dbname = "test",
+    unsigned_int = "character"
+  )
+  on.exit(dbDisconnect(con))
+
+  dbExecute(con, "CREATE TEMPORARY TABLE t_uint_chr (x INT UNSIGNED)")
+  dbExecute(con, "INSERT INTO t_uint_chr VALUES (0), (4294967295)")
+
+  out <- dbGetQuery(con, "SELECT x FROM t_uint_chr ORDER BY x")
+
+  expect_type(out$x, "character")
+  expect_equal(out$x, c("0", "4294967295"))
+})
+
+test_that("bigint and unsigned_int are honored independently", {
+  skip_if_not(mariadbHasDefault())
+  con <- dbConnect(
+    MariaDB(),
+    default.file = "~/.my.cnf",
+    group = "rs-dbi",
+    dbname = "test",
+    bigint = "integer",
+    unsigned_int = "numeric"
+  )
+  on.exit(dbDisconnect(con))
+
+  dbExecute(con, "CREATE TEMPORARY TABLE t_mixed (big BIGINT, uns INT UNSIGNED)")
+  dbExecute(con, "INSERT INTO t_mixed VALUES (100, 4294967295)")
+
+  out <- dbGetQuery(con, "SELECT big, uns FROM t_mixed")
+
+  expect_type(out$big, "integer")
+  expect_equal(out$big, 100L)
+
+  expect_type(out$uns, "double")
+  expect_false(inherits(out$uns, "integer64"))
+  expect_equal(out$uns, 4294967295)
+})
+
+test_that("signed INT is unaffected by unsigned_int setting", {
+  skip_if_not(mariadbHasDefault())
+  con <- dbConnect(
+    MariaDB(),
+    default.file = "~/.my.cnf",
+    group = "rs-dbi",
+    dbname = "test",
+    unsigned_int = "character"
+  )
+  on.exit(dbDisconnect(con))
+
+  dbExecute(con, "CREATE TEMPORARY TABLE t_sint (x INT)")
+  dbExecute(con, "INSERT INTO t_sint VALUES (0), (-1), (2147483647), (-2147483647)")
+
+  out <- dbGetQuery(con, "SELECT x FROM t_sint ORDER BY x")
+
+  expect_type(out$x, "integer")
+  expect_equal(out$x, c(-.Machine$integer.max, -1L, 0L, .Machine$integer.max))
+})

--- a/tests/testthat/test-unsigned-int.R
+++ b/tests/testthat/test-unsigned-int.R
@@ -1,0 +1,16 @@
+test_that("unsigned_int defaults to integer64 and preserves values above 2^31", {
+  skip_if_not(mariadbHasDefault())
+  con <- mariadbDefault()
+  on.exit(dbDisconnect(con))
+
+  dbExecute(con, "CREATE TEMPORARY TABLE t_uint (x INT UNSIGNED)")
+  dbExecute(con, "INSERT INTO t_uint VALUES (0), (1), (2147483647), (2147483648), (4294967295), (NULL)")
+
+  out <- dbGetQuery(con, "SELECT x FROM t_uint ORDER BY x IS NULL DESC, x")
+
+  expect_s3_class(out$x, "integer64")
+  expect_equal(
+    as.character(out$x),
+    c(NA, "0", "1", "2147483647", "2147483648", "4294967295")
+  )
+})


### PR DESCRIPTION
Attempt to fix #412 , #171 , #132 

Adds `is_unsigned` parameter to `variable_type_from_field_type`, and for unsigned ints (`MYSQL_TYPE_LONG`), will promote to `MY_DBL` instead of `MY_INT32`