### PR TITLE
fledge: CRAN release v1.3.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RMariaDB
 Title: Database Interface and MariaDB Driver
-Version: 1.3.4.9008
+Version: 1.3.5
 Authors@R: c(
     person("Kirill", "Müller", , "kirill@cynkra.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1416-3412")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,57 +10,7 @@
 
 - Remove plogr (#428).
 
-- Build-ignore.
-
-- Auto-update from GitHub Actions (#426).
-
 - Format C++ code with clang-format.
-
-- Auto-update from GitHub Actions (#411).
-
-## Continuous integration
-
-- Please.
-
-- Use clang-format-21.
-
-- Fix comment (#424).
-
-- Tweaks (#423).
-
-- Test all R versions on branches that start with cran- (#422).
-
-- Install binaries from r-universe for dev workflow (#419).
-
-- Fix reviewdog and add commenting workflow (#417).
-
-- Use workflows for fledge (#415).
-
-- Sync (#414).
-
-- Cleanup and fix macOS (#410).
-
-- Format with air, check detritus, better handling of `extra-packages` (#409).
-
-- Enhance permissions for workflow (#406).
-
-- Permissions, better tests for missing suggests, lints (#404).
-
-- Only fail covr builds if token is given (#401).
-
-- Always use `_R_CHECK_FORCE_SUGGESTS_=false` (#400).
-
-- Correct installation of xml2 (#397).
-
-- Explain (#395).
-
-- Add xml2 for covr, print testthat results (#394).
-
-- Sync (#393).
-
-## Uncategorized
-
-- Switching to development version.
 
 
 # RMariaDB 1.3.4 (2025-02-24)
@@ -160,7 +110,7 @@
 
 # RMariaDB 1.2.2 (2022-06-19)
 
-## Features 
+## Features
 
 - `dbAppendTable()` accepts `Id` (#262, @renkun-ken).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RMariaDB 1.3.4.9008 (2026-02-05)
+# RMariaDB 1.3.5 (2026-02-05)
 
 ## Bug fixes
 
@@ -10,27 +10,19 @@
 
 - Remove plogr (#428).
 
-## Continuous integration
-
-- Please.
-
-- Use clang-format-21.
-
-
-# RMariaDB 1.3.4.9007 (2026-02-02)
-
-## Chore
-
 - Build-ignore.
 
 - Auto-update from GitHub Actions (#426).
 
 - Format C++ code with clang-format.
 
-
-# RMariaDB 1.3.4.9006 (2026-01-14)
+- Auto-update from GitHub Actions (#411).
 
 ## Continuous integration
+
+- Please.
+
+- Use clang-format-21.
 
 - Fix comment (#424).
 
@@ -38,28 +30,9 @@
 
 - Test all R versions on branches that start with cran- (#422).
 
-
-# RMariaDB 1.3.4.9005 (2025-11-17)
-
-## Continuous integration
-
 - Install binaries from r-universe for dev workflow (#419).
 
-
-# RMariaDB 1.3.4.9004 (2025-11-12)
-
-## Continuous integration
-
 - Fix reviewdog and add commenting workflow (#417).
-
-
-# RMariaDB 1.3.4.9003 (2025-11-10)
-
-## Chore
-
-- Auto-update from GitHub Actions (#411).
-
-## Continuous integration
 
 - Use workflows for fledge (#415).
 
@@ -69,17 +42,7 @@
 
 - Format with air, check detritus, better handling of `extra-packages` (#409).
 
-
-# RMariaDB 1.3.4.9002 (2025-05-04)
-
-## Continuous integration
-
 - Enhance permissions for workflow (#406).
-
-
-# RMariaDB 1.3.4.9001 (2025-04-30)
-
-## Continuous integration
 
 - Permissions, better tests for missing suggests, lints (#404).
 
@@ -95,8 +58,7 @@
 
 - Sync (#393).
 
-
-# RMariaDB 1.3.4.9000 (2025-02-25)
+## Uncategorized
 
 - Switching to development version.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-RMariaDB 1.3.4
+RMariaDB 1.3.5
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2026-02-05, problems found: https://cran.r-project.org/web/checks/check_results_RMariaDB.html
- [ ] ERROR: r-devel-linux-x86_64-fedora-clang, r-devel-linux-x86_64-fedora-gcc
     Installation failed.
- [ ] other_issue: NA
See: <https://www.stats.ox.ac.uk/pub/bdr/M1mac/RMariaDB.log>
- [ ] other_issue: NA
See: <https://www.stats.ox.ac.uk/pub/bdr/M1mac/RMariaDB.out>
- [ ] other_issue: NA
See: <https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/RMariaDB.out>

Check results at: https://cran.r-project.org/web/checks/check_results_RMariaDB.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`

---

## Updated 2026-09-13: merged `main` in, so this applies cleanly

The release was cut on 2026-02-05 and never merged back. `main` carried on from 1.3.4.9008 and is now 74 commits ahead at 1.3.4.9024, so this PR conflicted and `v1.3.5` is not an ancestor of `main` — `git describe` on the tip cannot see the release. Merging `main` into the branch fixes both: the PR applies cleanly, and landing it puts the tag on the mainline.

**No code changes.** The merge result differs from `main` in exactly three files: `DESCRIPTION`, `NEWS.md` and `cran-comments.md`.

### `NEWS.md`

The release section consolidates the dev sections 1.3.4.9000 through 1.3.4.9008, which `main` still lists individually. Keeping both would state the same changes twice under two different version numbers, so the nine are dropped and the `# RMariaDB 1.3.5` section stands in their place. The file now reads:

- `# RMariaDB 1.3.5.9001` — new, this PR
- `# RMariaDB 1.3.4.9024` … `# RMariaDB 1.3.4.9009` — unchanged from `main`, the work done after the release was cut
- `# RMariaDB 1.3.5 (2026-02-05)` — the release
- `# RMariaDB 1.3.4` and older — unchanged

The numbering therefore goes back to 1.3.4.9xxx below the top section. That is a true record of what happened: those commits really were made against a tree that did not know about 1.3.5. Adding the 1.3.5.9001 section on top is what keeps the current dev version above the release.

### `DESCRIPTION`

`Version: 1.3.5.9001`, taking `main`'s content otherwise.

### After merging

`v1.3.5.9001` needs a tag on the resulting commit, to match the convention every other dev bump in this repo follows.

Please **merge with a merge commit**. A squash would drop the second parent, and `v1.3.5` would stay off the mainline exactly as it is now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hcbd7RdNjqre33JRgc86j8