### PR TITLE
ci: source dev-package deps from P3M, keep only target dev from r-universe

### DIFF
--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -125,7 +125,42 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          remotes::install_runiverse("${{ matrix.package }}", linux_distro = "noble")
+          pkg <- "${{ matrix.package }}"
+
+          # P3M (Posit Package Manager) binary repo, used for released deps in step 2.
+          p3m <- Sys.getenv("RSPM")
+          if (!nzchar(p3m)) p3m <- "https://packagemanager.posit.co/cran/__linux__/noble/latest"
+
+          # 1. Install ONLY the dev package from its r-universe repo, WITHOUT
+          #    dependencies. `linux_distro = "noble"` is kept so we pull a fast
+          #    *binary* build from r-universe rather than compiling from source.
+          #    CAVEAT: r-universe has renamed its Linux binary distro from
+          #    "noble" to "resolute", so this hardcoded value can start returning
+          #    404 for some packages (it already broke a dev `tidyr` install).
+          #    Kept for now to preserve binary installs; update or drop
+          #    `linux_distro` once it 404s.
+          remotes::install_runiverse(pkg, dependencies = FALSE, linux_distro = "noble")
+
+          # 2. The dev package may declare NEW hard dependencies that its released
+          #    version (installed earlier from P3M by the pak step) lacks -- e.g.
+          #    dev DBItest added `purrr`, dev `tidyr` links to `cpp11`. Read them
+          #    off the freshly installed dev package and install the missing ones
+          #    from P3M, so dependencies come in as *released* binaries instead of
+          #    dragging dev versions of the whole tree from r-universe. Set repos
+          #    explicitly because step 1 may have pointed them at r-universe.
+          deps <- tools::package_dependencies(
+            pkg,
+            db = installed.packages(),
+            which = c("Depends", "Imports", "LinkingTo")
+          )[[pkg]]
+          deps <- setdiff(deps, rownames(installed.packages()))
+          if (length(deps)) install.packages(deps, repos = p3m)
+
+          # 3. Re-install the dev package from r-universe with dependencies = TRUE.
+          #    Its hard deps are now satisfied from P3M, so this only ensures the
+          #    dev package itself is in place and fills any residual gaps, without
+          #    pulling the entire dependency tree from r-universe.
+          remotes::install_runiverse(pkg, dependencies = TRUE, linux_distro = "noble")
         shell: Rscript {0}
 
       - name: Session info

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,6 @@ Imports:
 Suggests: 
     DBItest (>= 1.7.2.9001),
     decor,
-    purrr,
     readr,
     rprojroot,
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
 Suggests: 
     DBItest (>= 1.7.2.9001),
     decor,
+    purrr,
     readr,
     rprojroot,
     testthat (>= 3.0.0),


### PR DESCRIPTION
## Problem

The `rcc dev` workflow (`.github/workflows/R-CMD-check-dev.yaml`) has been failing. The `rcc-dev: DBItest` job's R CMD check step fails during the test suite:

```
── Error ('test-DBItest.R:4:3'): (code run outside of `test_that()`) ──

Error in `loadNamespace(x)`: there is no package called 'purrr'
 4. └─DBItest:::get_skip_names(skip) at DBItest/R/run.R:33:3
 5. └─base::loadNamespace(x) at DBItest/R/run.R:119:3
[ FAIL 1 | WARN 0 | SKIP 1 | PASS 57 ]
```

## Root cause

The failing symptom is that dev `DBItest` calls `purrr::map()`/`purrr::map_lgl()` in `get_skip_names()`, and `purrr` is not present. But the earlier fix — adding `purrr` to `Suggests` — only masked the problem. The real bug is in the workflow's **"Install dev version"** step.

That step ran:

```r
remotes::install_runiverse("${{ matrix.package }}", linux_distro = "noble")
```

`remotes::install_runiverse()` installs the dev package **without its dependencies**. When dev `DBItest` added `purrr` to its `Imports`, that new hard dependency was never installed — the released `DBItest` pulled in earlier (from P3M by the pak step) had no such dependency to satisfy it. Adding `purrr` to RMariaDB's own `Suggests` happened to bring `purrr` in as a side effect, but that is a coincidental workaround: it does not fix the general case (any dev package that grows a new hard dependency would break the same way), and it pollutes RMariaDB's `DESCRIPTION` with a dependency it does not itself use.

## Fix

Rework the **"Install dev version"** step into a three-phase install so dev packages come from r-universe while their dependencies come as released binaries from P3M:

1. **Install ONLY the dev package from r-universe, WITHOUT dependencies.** `linux_distro = "noble"` is kept so we pull a fast *binary* build from r-universe rather than compiling from source.
2. **Install any NEW hard dependencies from P3M.** The dev package may declare hard deps (`Depends`/`Imports`/`LinkingTo`) that its released version lacked — e.g. dev `DBItest` added `purrr`, dev `tidyr` links to `cpp11`. These are read off the freshly installed dev package and the missing ones are installed from P3M (`RSPM`, defaulting to `https://packagemanager.posit.co/cran/__linux__/noble/latest`), so dependencies arrive as *released* binaries instead of dragging dev versions of the whole tree from r-universe.
3. **Re-install the dev package from r-universe with `dependencies = TRUE`.** Its hard deps are now satisfied from P3M, so this only ensures the dev package itself is in place and fills any residual gaps, without pulling the entire dependency tree from r-universe.

The coincidental `purrr`-in-`Suggests` workaround (commit `fe2e5eb`) is **reverted** in this PR.

### `noble` caveat

`linux_distro = "noble"` is hardcoded to preserve fast binary installs. r-universe has renamed its Linux binary distro from `noble` to `resolute`, so this value can start returning 404 for some packages (it already broke a dev `tidyr` install). It is kept for now; `linux_distro` should be updated or dropped once it 404s.

## Verification

- YAML lints clean (`yaml.safe_load`).
- The full `rcc dev` R CMD check (with a live MariaDB server and the r-universe dev `DBItest`) is exercised by CI; a `workflow_dispatch` run was triggered on this branch. Not reproducible end-to-end in the local environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7