### PR TITLE
ci: Adapt database setup to what ankane's actions offer on Ubuntu 26.04

### DIFF
--- a/.github/versions-matrix.R
+++ b/.github/versions-matrix.R
@@ -1,11 +1,17 @@
+# The Linux combos run on ubuntu-26.04, in line with the workflow template.
+#
+# "MySQL server, MariaDB client" is gone: on Ubuntu 26.04 the `mysql-server`
+# package declares `Conflicts: mariadb-common`, and `mariadb-common` is pulled
+# in by `libmariadb-dev`, so a MySQL server and a MariaDB client cannot be
+# installed side by side anymore.
 mysql_combos <- data.frame(
-  os = c("macos-latest", "macos-latest", "ubuntu-22.04", "ubuntu-22.04", "ubuntu-22.04", "ubuntu-22.04"),
+  os = c("macos-latest", "macos-latest", "ubuntu-26.04", "ubuntu-26.04", "ubuntu-26.04"),
   r = "release",
-  mysql_client = c("false", "true", "true", "true", "false", "false"),
-  RMARIADB_FORCE_MARIADBCONFIG = c(1, NA, NA, NA, NA, NA),
-  RMARIADB_FORCE_MYSQLCONFIG = c(NA, 1, NA, NA, NA, NA),
-  mysql_server = c(NA, NA, "true", "false", "true", "false"),
-  desc = c("mariadb_config", "mysql_config", "MySQL server", "MariaDB server, MySQL client", "MySQL server, MariaDB client", "MariaDB server + client")
+  mysql_client = c("false", "true", "true", "true", "false"),
+  RMARIADB_FORCE_MARIADBCONFIG = c(1, NA, NA, NA, NA),
+  RMARIADB_FORCE_MYSQLCONFIG = c(NA, 1, NA, NA, NA),
+  mysql_server = c(NA, NA, "true", "false", "false"),
+  desc = c("mariadb_config", "mysql_config", "MySQL server", "MariaDB server, MySQL client", "MariaDB server + client")
 )
 windows_versions <- data.frame(os = "windows-latest", r = r_versions[4:5])
 list(mysql_combos, windows_versions)

--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -3,13 +3,13 @@ name: 'Custom steps to run after R packages are installed'
 runs:
   using: "composite"
   steps:
-    # Must happen after installing system dependencies,
-    # https://github.com/ankane/setup-mariadb/issues/2
-    - name: Purge MySQL server
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt purge -y mysql-server
-      shell: bash
+    # No need to purge the MySQL server first anymore
+    # (https://github.com/ankane/setup-mariadb/issues/2):
+    # setup-mariadb stops `mysql.service` and wipes `/var/lib/mysql` itself,
+    # and its `mariadb-server` package conflicts with `mysql-server`,
+    # so apt removes the latter.
+    # Purging beforehand deletes the systemd unit
+    # that setup-mariadb wants to stop, which makes the action fail.
 
     - name: Purge mariadb-connector-c if it exists
       if: runner.os == 'macOS'
@@ -17,15 +17,32 @@ runs:
         brew unlink mariadb-connector-c || true
       shell: bash
 
+    # Version pins follow what ankane's actions support on ubuntu-26.04:
+    # MariaDB 12.3 (default) and 11.8, MySQL 8.4 only.
+    # 11.8 and 8.4 are also available on the other runner images in the matrix.
     - uses: ankane/setup-mariadb@v1
       if: (matrix.config.mysql_server == '') || ! matrix.config.mysql_server
       with:
-        mariadb-version: "11.4"
+        mariadb-version: "11.8"
 
     - uses: ankane/setup-mysql@v1
       if: matrix.config.mysql_server
       with:
-        mysql-version: 8.0
+        mysql-version: "8.4"
+
+    - name: Install and check MariaDB client (Linux)
+      # Bare `mariadb_config` segfaults with the `libmariadb-dev` shipped by
+      # Ubuntu 26.04 (1:11.8.6-5ubuntu0.1), so query the individual settings
+      # that `configure` uses instead.
+      if: runner.os == 'Linux' && ((matrix.config.mysql_client == '') || ! matrix.config.mysql_client)
+      run: |
+        sudo apt-get purge -y libmysqlclient-dev
+        sudo apt-get update -y
+        sudo apt-get install -y libmariadb-dev
+        mariadb_config --version
+        mariadb_config --cflags
+        mariadb_config --libs
+      shell: bash
 
     # Use hard-coded time zone info so that it also works on Windows
     - name: Create database, set it to UTF-8, add time zone info

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -8,14 +8,17 @@ runs:
         echo '_R_CHECK_PKG_SIZES_=FALSE' | tee -a $GITHUB_ENV
       shell: bash
 
-    - name: Clean up broken mysql apt
-      # FIXME: Remove if package becomes unavailable
+    - name: Install legacy time zone data (Linux)
+      # Ubuntu 26.04 no longer ships the backward-compatibility zone names
+      # (PST8PDT, EST5EDT, US/Pacific, ...) in `tzdata`;
+      # they moved to the separate `tzdata-legacy` package.
+      # DBItest exercises PST8PDT,
+      # and without the package `lubridate::with_tz()` warns
+      # "Unrecognized time zone", which fails the round-trip timestamp tests.
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        if [ $(lsb_release --short --codename) == 'focal' ]; then
-          sudo apt-get install mysql-common=5.8+1.0.5ubuntu2 --allow-downgrades
-        fi
+        sudo apt-get install -y tzdata-legacy
       shell: bash
 
     - name: Install MariaDB client (macOS)
@@ -29,7 +32,9 @@ runs:
       if: runner.os == 'macOS' && ((matrix.config.mysql_client == '' ) || ! matrix.config.mysql_client)
       run: |
         brew install mariadb-connector-c
-        mariadb_config
+        mariadb_config --version
+        mariadb_config --cflags
+        mariadb_config --libs
       shell: bash
 
     - name: Install MySQL client (macOS)
@@ -48,14 +53,13 @@ runs:
         mysql_config || true
       shell: bash
 
-    - name: Install and check MariaDB client (Linux)
-      if: runner.os == 'Linux' && ((matrix.config.mysql_client == '' ) || ! matrix.config.mysql_client)
-      run: |
-        sudo apt-get purge -y libmysqlclient-dev
-        sudo apt-get update -y
-        sudo apt-get install -y libmariadb-dev
-        mariadb_config
-      shell: bash
+    # The Linux client is installed in the after-install action,
+    # after the database server has been set up:
+    # on Ubuntu 26.04 `libmariadb-dev` pulls in `mariadb-common`,
+    # which conflicts with `mysql-server` and therefore uninstalls it
+    # (including its systemd unit) --
+    # `ankane/setup-mariadb` expects the image's MySQL to still be there
+    # so that it can stop it before installing MariaDB.
 
     - name: Define client restrictons
       run: |


### PR DESCRIPTION
The `rcc` workflow now runs on `ubuntu-26.04`, and the smoke test dies in `custom/before-install` before R is even installed. This adapts the database setup to that image.

## What was broken

**1. `mariadb_config` segfaults.** The check step ran a bare `mariadb_config`, which crashes with the `libmariadb-dev` that Ubuntu 26.04 ships (`1:11.8.6-5ubuntu0.1`):

```
line 4: 2698 Segmentation fault (core dumped) mariadb_config
##[error]Process completed with exit code 139
```

Reproduced against that exact `.deb`: bare invocation segfaults, while `--version`, `--cflags` and `--libs` — the ones `configure` actually calls — all return normally.

**2. The pinned server versions no longer exist on that image.** Per ankane's support matrices, `ubuntu-26.04` offers MariaDB 12.3 (default) and 11.8 — 11.4 is gone — and MySQL 8.4 only. The workflow pinned MariaDB 11.4 and MySQL 8.0.

**3. Installing the client before the server breaks the server setup.** On Ubuntu 26.04, `mysql-server` declares `Conflicts: mariadb-common`, and `libmariadb-dev` pulls `mariadb-common` in, so `apt-get install libmariadb-dev` uninstalls MySQL — including `/usr/lib/systemd/system/mysql.service`. `ankane/setup-mariadb` starts by stopping `mysql.service`, so it would fail on the unit that step just deleted. The explicit `apt purge mysql-server` in `after-install` had the same effect.

**4. `PST8PDT` is unknown.** Ubuntu 26.04 moved the backward-compatibility zone names out of `tzdata` into `tzdata-legacy`. DBItest exercises `PST8PDT`, and `lubridate::with_tz()` warns "Unrecognized time zone" without it. This is the failure RPostgres hits on the same image (r-dbi/RPostgres#593).

## What changed

- Pin MariaDB `11.8` and MySQL `8.4`; both are available on every runner image in the matrix, not just `ubuntu-26.04`.
- Move the Linux client install from `before-install` to `after-install`, after the server action has run, and drop the pre-emptive `apt purge mysql-server` — `ankane/setup-mariadb` stops MySQL and wipes `/var/lib/mysql` itself these days, so the workaround for ankane/setup-mariadb#2 is now the thing doing the damage.
- Query `mariadb_config` with explicit flags instead of bare, on Linux and macOS alike.
- Install `tzdata-legacy` on Linux.
- Move the custom version matrix from `ubuntu-22.04` to `ubuntu-26.04`, in line with the workflow template, and drop the "MySQL server, MariaDB client" combo — the apt conflict above makes it uninstallable on that image.

## Note for a follow-up

`before-install`/`after-install` read the matrix as `matrix.config.mysql_server` etc., but `.github/workflows/versions-matrix` emits flat entries (`matrix.mysql_server`). Every Linux job therefore takes the MariaDB-server/MariaDB-client path regardless of its `desc`, and the `RMARIADB_FORCE_*` variables are never set. Rewiring that changes what is actually tested, so it is deliberately left out of this PR.
