### PR TITLE
fix(ci): Drop the ARM64 Windows entry, which has no MariaDB server

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,14 @@ Config/Needs/website:
 Config/autostyle/scope: line_breaks
 Config/autostyle/strict: false
 Config/testthat/edition: 3
+Config/gha/filter: os != "windows-11-arm"
+Config/comment/gha/filter: No MariaDB server exists for ARM64 Windows, and the
+    DBItest suite needs a live one -- it connects in
+    tests/testthat/helper-DBItest.R and has no path that skips when the server
+    is absent. ankane/setup-mariadb falls back to the winx64 MSI there and
+    msiexec cannot install it, so the entry dies in after-install after about
+    four and a half minutes. Drop this filter once MariaDB publishes an ARM64
+    Windows server.
 Encoding: UTF-8
 NeedsCompilation: yes
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
`rcc: windows-11-arm (4.6)` has failed every scheduled run for about two weeks — I checked back twelve days and found no green one. It is the only red job in the run, and it dies in "Run the repository-specific after-install steps" before a single check:

```
C:\Windows\System32\curl.exe -Ls -o mariadb.msi https://dlm.mariadb.com/MariaDB/mariadb-11.8.2/winx64-packages/mariadb-11.8.2-winx64.msi
msiexec /i mariadb.msi SERVICENAME=MariaDB /qn
   ... 4m45s later ...
C:\a\_actions\ankane\setup-mariadb\v1\index.js:16
    throw ret.error;
```

MariaDB publishes no ARM64 Windows server, so `ankane/setup-mariadb` falls back to the `winx64` MSI and `msiexec` cannot install it on that runner. No version pin fixes this — there is nothing to point it at.

Skipping just the provisioning would not help. `tests/testthat/helper-DBItest.R` builds its context by connecting, and there is no path that skips when no server is present, so the failure would move out of `after-install` and into `R CMD check`. With no server available on that platform at all, the entry can only ever be red, so it comes out of the matrix.

`Config/gha/filter` is the kit's own knob for this — the shared `versions-matrix` action applies it as `subset(x, <expr>)` to each frame of the include list. The accompanying `Config/comment/gha/filter` records the reason and what would let the entry come back.

Verified by running the exact `subset()` the action performs against representative matrix frames: `windows-11-arm` drops, every other entry (macOS, `windows-latest`, `ubuntu-26.04`, `ubuntu-26.04-arm`) is untouched.

Sibling change for the same upstream gap: r-dbi/RPostgres. r-dbi/DBI#746 hits the same wall but takes the opposite remedy — its own suite never connects to that server, so it skips the provisioning and keeps the ARM Windows entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML)_